### PR TITLE
msm8996-common: Don't build vendor.lineage.livedisplay-V1.0-java

### DIFF
--- a/msm8996.mk
+++ b/msm8996.mk
@@ -270,11 +270,7 @@ PRODUCT_PACKAGES += \
 
 # LiveDisplay native
 PRODUCT_PACKAGES += \
-    vendor.lineage.livedisplay@1.0-service-sdm \
-    vendor.lineage.livedisplay-V1.0-java
-
-PRODUCT_BOOT_JARS += \
-    vendor.lineage.livedisplay-V1.0-java
+    vendor.lineage.livedisplay@1.0-service-sdm
 
 # Media
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
 * The static version is in use now.

Change-Id: Ia400068dea959ae8a0665117046d390fb12ba6ff